### PR TITLE
Added expliсit import for swagger `Authorization`

### DIFF
--- a/src/main/resources/mustache/JavaSpring/api.mustache
+++ b/src/main/resources/mustache/JavaSpring/api.mustache
@@ -11,6 +11,7 @@ package {{package}};
 import com.fasterxml.jackson.databind.ObjectMapper;
 {{/jdk8-no-delegate}}
 import io.swagger.annotations.*;
+import io.swagger.annotations.Authorization;
 {{#jdk8-no-delegate}}
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
It is needed to add explicit import `io.swagger.annotations.Authorization;` because there is object with the same name. As a result generated class has problem with imports.