### PR TITLE
Fix equals generation for subclasses without any properties

### DIFF
--- a/src/main/resources/mustache/JavaSpring/pojo.mustache
+++ b/src/main/resources/mustache/JavaSpring/pojo.mustache
@@ -106,11 +106,15 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
     }
     if (o == null || getClass() != o.getClass()) {
       return false;
-    }{{#hasVars}}
+}{{#parent}}
+    if (!super.equals(o)) {
+    return false;
+    }
+{{/parent}}
+{{#hasVars}}
     {{classname}} {{classVarName}} = ({{classname}}) o;
     return {{#vars}}Objects.equals(this.{{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
-        {{/hasMore}}{{/vars}}{{#parent}} &&
-        super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
+    {{/hasMore}}{{/vars}};{{/hasVars}}{{^hasVars}}
     return true;{{/hasVars}}
   }
 


### PR DESCRIPTION
At the moment `equals` method in subclass will include superclass properties only if the subclass itself has any property. This fix ensures that even if subclass has no properties at all, `equals` of the superclass will still be called